### PR TITLE
Readded line missing from except HTTPError block

### DIFF
--- a/unirest/__init__.py
+++ b/unirest/__init__.py
@@ -98,6 +98,7 @@ def __request(method, url, params={}, headers={}, auth=None, callback=None):
             response = urllib2.urlopen(req, timeout=_timeout)
             _unirestResponse = UnirestResponse(response.code, response.headers, response.read())
         except urllib2.HTTPError, e:
+            response = e
             _unirestResponse = UnirestResponse(response.code, response.headers, response.read())
         except urllib2.URLError, e:
             _unirestResponse = UnirestResponse(0, {}, str(e.reason))


### PR DESCRIPTION
A line got lost when reworking the try/except blocks. This line is needed to bind "response" to an appropriate object to pass to UnirestResponse.
